### PR TITLE
Show each matchup in seeded order

### DIFF
--- a/BracketGame.tsx
+++ b/BracketGame.tsx
@@ -99,9 +99,11 @@ class BracketGame extends React.PureComponent<BracketGameProps> {
 		} = this.props
 
 		const { sides } = game
+		
+		const homeTopEmoji = (sides[Side.HOME].seed && sides[Side.HOME].seed.sourceGame) ? [sides[Side.HOME].seed.sourceGame.sides[Side.HOME].team.id, sides[Side.HOME].seed.sourceGame.sides[Side.VISITOR].team.id].indexOf(sides[Side.HOME].team.id) >= 0 : true
 
-		const top = sides[homeOnTop ? Side.HOME : Side.VISITOR]
-		const bottom = sides[homeOnTop ? Side.VISITOR : Side.HOME]
+		const top = sides[homeTopEmoji ? Side.HOME : Side.VISITOR]
+		const bottom = sides[homeTopEmoji ? Side.VISITOR : Side.HOME]
 
 		const winnerBackground =
 			top &&


### PR DESCRIPTION
I noticed each matchup showed the loser on the top and the winner on the bottom.  This patch should show the emoji in seeded order, allowing users to more easily trace the flow of the competition.