### PR TITLE
Tweak plural text

### DIFF
--- a/ui.tsx
+++ b/ui.tsx
@@ -169,7 +169,7 @@ class UI extends React.Component {
 				</h1>
 
 				<div>
-					Hiding first {this.startLevel} levels{" "}
+					Hiding first {this.startLevel} level(s){" "}
 					<button onClick={e => this.startLevel--}>-</button>
 					<button onClick={e => this.startLevel++}>+</button>
 				</div>


### PR DESCRIPTION
If only one level is shown, we should not say "1 levels". 

A more proper fix would be to output "level" for 1 and "levels" for everything else, but that would be a non-trivial amount of work.